### PR TITLE
Rename trailerYoutubeUrl to youtubeVideoId in Game schema, validation, and model.

### DIFF
--- a/src/common/swagger/schema/game.yml
+++ b/src/common/swagger/schema/game.yml
@@ -127,10 +127,10 @@ components:
           type: number
           example: 18
           description: Game age rating
-        trailerYoutubeUrl:
+        youtubeVideoId:
           type: string
-          format: uri
-          example: 'https://www.youtube.com/watch?v=dQw4w9WgXcQ'
+          format: youtube video id
+          example: 'dQw4w9WgXcQ'
           description: Game trailer YouTube URL
         createdAt:
           type: string
@@ -192,8 +192,7 @@ components:
           example: 18
         trailerYoutubeUrl:
           type: string
-          format: uri
-          example: 'https://www.youtube.com/watch?v=dQw4w9WgXcQ'
+          example: 'Qw4w9WgXcQ'
   requestBodies:
     AddGameRequest:
       description: Request body for adding a game

--- a/src/common/swagger/schema/game.yml
+++ b/src/common/swagger/schema/game.yml
@@ -190,7 +190,7 @@ components:
         ageRating:
           type: number
           example: 18
-        trailerYoutubeUrl:
+        youtubeVideoId:
           type: string
           example: 'Qw4w9WgXcQ'
   requestBodies:

--- a/src/common/validation-schema/game/add-game.ts
+++ b/src/common/validation-schema/game/add-game.ts
@@ -124,7 +124,7 @@ export const AddGameZodSchema = z.object({
     })
     .optional(),
 
-  trailerYoutubeUrl: z
+  youtubeVideoId: z
     .string({
       message: 'Trailer youtube url must be string',
     })

--- a/src/models/game.model.ts
+++ b/src/models/game.model.ts
@@ -24,7 +24,7 @@ export interface IGame extends Document {
   avgPlaytime?: number;
   developer: string;
   ageRating: number;
-  trailerYoutubeUrl: string;
+  youtubeVideoId?: string;
 }
 
 //schema
@@ -90,7 +90,7 @@ const GameSchema: Schema = new Schema(
       type: Number,
       required: false,
     },
-    trailerYoutubeUrl: {
+    youtubeVideoId: {
       type: String,
       required: false,
       default: '',


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- Refactor
  - Renamed public trailer field to youtubeVideoId across game APIs; endpoints now use a YouTube video ID (not a full URL). Client integrations must update requests and handle responses accordingly.

- Documentation
  - API schema and examples updated to show youtubeVideoId format (YouTube video ID instead of URL).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->