### PR TITLE
Fix AddUserRequest swagger required fields nesting

### DIFF
--- a/src/common/swagger/schema/user.yml
+++ b/src/common/swagger/schema/user.yml
@@ -71,14 +71,14 @@ components:
   requestBodies:
     AddUserRequest:
       description: Request body for adding a new user
-      required:
-        - name
-        - email
-        - password
       content:
         application/json:
           schema:
             type: object
+            required:
+              - name
+              - email
+              - password
             properties:
               name:
                 type: string


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated Add User API documentation to clearly indicate required fields (name, email, password) within the request body schema.
  * Improves consistency and readability of the API spec without altering API behavior.
  * Helps developers validate requests more reliably based on the documented requirements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->