### PR TITLE
Rename trailerYoutubeUrl to youtubeVideoId and add averageRating to Season model

### DIFF
--- a/docs/phase1_models.md
+++ b/docs/phase1_models.md
@@ -38,18 +38,19 @@ The following is a description of the database models used in the application ph
 
 #### Table: TV Seasons
 
-| Field Name        | Data Type | Description                           |
-| ----------------- | --------- | ------------------------------------- |
-| tvShow            | ObjectId  | Reference to the TV show              |
-| seasonNumber      | number    | Season number                         |
-| title             | string    | Season title                          |
-| description       | string    | Season description                    |
-| releaseDate       | date      | Season release date                   |
-| noOfEpisodes      | number    | Number of episodes                    |
-| posterUrl         | string    | Season poster URL                     |
-| seasonRating      | number    | Season rating                         |
-| status            | string    | Season status (enum: `SEASON_STATUS`) |
-| trailerYoutubeUrl | string    | Season trailer YouTube URL            |
+| Field Name     | Data Type | Description                               |
+| -------------- | --------- | ----------------------------------------- |
+| tvShow         | ObjectId  | Reference to the TV show                  |
+| seasonNumber   | number    | Season number                             |
+| title          | string    | Season title                              |
+| description    | string    | Season description                        |
+| releaseDate    | date      | Season release date                       |
+| noOfEpisodes   | number    | Number of episodes                        |
+| posterUrl      | string    | Season poster URL                         |
+| seasonRating   | number    | Season rating                             |
+| status         | string    | Season status (enum: `SEASON_STATUS`)     |
+| youtubeVideoId | string    | Season trailer YouTube embed ID           |
+| averageRating  | number    | average user rating for the season (0-10) |
 
 ### TV Episode Model
 
@@ -68,34 +69,43 @@ The following is a description of the database models used in the application ph
 
 #### Table: Movies
 
-| Field Name    | Data Type     | Description                           |
-| ------------- | ------------- | ------------------------------------- |
-| title         | string        | Movie title                           |
-| description   | string        | Movie description                     |
-| averageRating | number        | Movie average rating                  |
-| genre         | array[string] | Movie genres (enum: `GENRE_MOVIE_TV`) |
-| releaseDate   | string        | Movie release date                    |
-| cast          | array[string] | Movie cast                            |
-| directors     | array[string] | Movie directors                       |
-| runTime       | number        | Movie run time                        |
-| languages     | array[string] | Movie languages                       |
-| posterUrl     | string        | Movie poster URL                      |
+| Field Name     | Data Type     | Description                           |
+| -------------- | ------------- | ------------------------------------- |
+| title          | string        | Movie title                           |
+| description    | string        | Movie description                     |
+| averageRating  | number        | Movie average rating                  |
+| genre          | array[string] | Movie genres (enum: `GENRE_MOVIE_TV`) |
+| releaseDate    | string        | Movie release date                    |
+| cast           | array[string] | Movie cast                            |
+| directors      | array[string] | Movie directors                       |
+| runTime        | number        | Movie run time                        |
+| languages      | array[string] | Movie languages                       |
+| posterUrl      | string        | Movie poster URL                      |
+| backdropUrl    | string        | Movie backdrop URL                    |
+| isActive       | boolean       | Movie active status                   |
+| status         | string        | Movie status (enum: `MEDIA_STATUS`)   |
+| tags           | array[string] | Movie tags                            |
+| ageRating      | number        | Movie age rating                      |
+| youtubeVideoId | string        | Movie trailer YouTube embed ID        |
 
 ### Game Model
 
 #### Table: Games
 
-| Field Name    | Data Type     | Description                        |
-| ------------- | ------------- | ---------------------------------- |
-| title         | string        | Game title                         |
-| description   | string        | Game description                   |
-| averageRating | number        | Game average rating                |
-| genre         | array[string] | Game genres (enum: `GAME_GENRES`)  |
-| releaseDate   | string        | Game release date                  |
-| posterUrl     | string        | Game poster URL                    |
-| backdropUrl   | string        | Game backdrop URL                  |
-| isActive      | boolean       | Game active status                 |
-| status        | string        | Game status (enum: `MEDIA_STATUS`) |
-| platforms     | array[string] | Game platforms                     |
+| Field Name     | Data Type     | Description                        |
+| -------------- | ------------- | ---------------------------------- |
+| title          | string        | Game title                         |
+| description    | string        | Game description                   |
+| averageRating  | number        | Game average rating                |
+| genre          | array[string] | Game genres (enum: `GAME_GENRES`)  |
+| releaseDate    | date          | Game release date                  |
+| posterUrl      | string        | Game poster URL                    |
+| backdropUrl    | string        | Game backdrop URL                  |
+| isActive       | boolean       | Game active status                 |
+| status         | string        | Game status (enum: `MEDIA_STATUS`) |
+| platforms      | array<string> | Game platforms                     |
+| developer      | string        | Game developer                     |
+| ageRating      | number        | Game age rating                    |
+| youtubeVideoId | string        | Game trailer embed ID              |
 
 Note: The `ObjectId` type refers to the MongoDB ObjectId type, which is used to reference other documents in the database.

--- a/docs/rest_phase1.http
+++ b/docs/rest_phase1.http
@@ -1,5 +1,5 @@
 @baseUrl = http://localhost:3001
-@authToken = Bearer <token>
+@authToken = Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpZCI6IjY4NzI4NzdjMDkwZGJjZTI5NGViY2Q2NSIsImlhdCI6MTc1OTY0MTQwNiwiZXhwIjoxNzU5NzI3ODA2fQ.QDNKw42-GIQAcl8OnevolpL7tRrdskSCv1Ub9x5PGuQ
 ##-------------------------------------------- USER -------------------------------------------------------------
 ### add user
 POST {{baseUrl}}/api/user
@@ -403,30 +403,35 @@ Authorization: {{authToken}}
 Content-Type: application/json
 
 {
-  "tvShow": "687b38b2fda2a91d0f01d59a",
-  "seasonNumber": 1,
-  "title": "Season 1",
+  "tvShow": "688ba5819f1d3f352d1b1ef8",
+  "seasonNumber": 2,
+  "title": "Season 2",
   "description": "The first season of The Startup.",
-  "releaseDate": "2023-09-10",
+  "releaseDate": "2023-09-10T00:00:00.000Z",
   "noOfEpisodes": 2,
-  "posterUrl": "https://example.com/posters/startup-s1.jpg",
+  "posterUrl": "",
   "seasonRating": 7.8,
   "status": "ended",
-  "trailerYoutubeUrl": "https://www.youtube.com/watch?v=example",
+  "averageRating": 9,
+  "youtubeVideoId": "CrtcTnmuKhE",
   "episodes": [
     {
       "title": "Launch Day",
       "description": "The team scrambles to fix bugs before their big product launch.",
       "episodeNumber": 1,
-      "releaseDate": "2023-09-10",
-      "runTime": 30
+      "releaseDate": "2023-09-10T00:00:00.000Z",
+      "runTime": 30 ,
+      "stillUrl": "https://image.tmdb.org/t/p/w600_and_h900_bestv2/yb4F1Oocq8GfQt6iIuAgYEBokhG.jpg",
+      "averageRating": 9
     },
     {
       "title": "First Customer",
       "description": "The startup gets its first customer, but things don't go as planned.",
       "episodeNumber": 2,
-      "releaseDate": "2023-09-17",
-      "runTime": 32
+      "releaseDate": "2023-09-10T00:00:00.000Z",
+      "runTime": 30 ,
+      "stillUrl": "https://image.tmdb.org/t/p/w600_and_h900_bestv2/yb4F1Oocq8GfQt6iIuAgYEBokhG.jpg",
+      "averageRating": 9
     }
   ]
 }
@@ -468,20 +473,21 @@ Content-Type: application/json
 }
 
 ### get season by id 
-GET {{baseUrl}}/api/tv-show/season/687b38b2fda2a91d0f01d59c
+GET {{baseUrl}}/api/tv-show/season/68e234124a9e24bf643f7251
 
 ### get season by id with episode details 
-GET {{baseUrl}}/api/tv-show/season/687b38b2fda2a91d0f01d59c?fullDetails=true
+GET {{baseUrl}}/api/tv-show/season/68e234124a9e24bf643f7251?fullDetails=true
 
 ### update a season by id 
-PATCH {{baseUrl}}/api/tv-show/season/687b38b2fda2a91d0f01d59c
+PATCH {{baseUrl}}/api/tv-show/season/68e234124a9e24bf643f7251
 Authorization: {{authToken}}
 Content-Type: application/json
 
 {
-  "description" : "updated title"
+  "description" : "updated title",
+  "averageRating": 8
 }
 
 ### delete the season by id (all the associated episodes will also be deleted)
-DELETE {{baseUrl}}/api/tv-show/season/688650616452857ec142d164
+DELETE {{baseUrl}}/api/tv-show/season/68e234124a9e24bf643f7251
 Authorization: {{authToken}}

--- a/docs/rest_phase1.http
+++ b/docs/rest_phase1.http
@@ -1,5 +1,5 @@
 @baseUrl = http://localhost:3001
-@authToken = Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpZCI6IjY4NzI4NzdjMDkwZGJjZTI5NGViY2Q2NSIsImlhdCI6MTc1OTY0MTQwNiwiZXhwIjoxNzU5NzI3ODA2fQ.QDNKw42-GIQAcl8OnevolpL7tRrdskSCv1Ub9x5PGuQ
+@authToken = Bearer <token>
 ##-------------------------------------------- USER -------------------------------------------------------------
 ### add user
 POST {{baseUrl}}/api/user

--- a/src/common/swagger/schema/tv-season.yml
+++ b/src/common/swagger/schema/tv-season.yml
@@ -9,7 +9,6 @@ components:
       required:
         - seasonNumber
         - title
-        - releaseDate
         - noOfEpisodes
         - status
       properties:
@@ -28,7 +27,8 @@ components:
         releaseDate:
           type: string
           description: Release date (ISO format, YYYY-MM-DD).
-          example: '2022-02-15'
+          format: date-time
+          example: '2022-02-15T00:00:00.000Z'
         noOfEpisodes:
           type: integer
           description: Number of episodes in the season.
@@ -48,10 +48,15 @@ components:
           description: Status of the season.
           enum: ['ended', 'upcoming', 'on-going']
           example: 'ended'
-        trailerYoutubeUrl:
+        youtubeVideoId:
           type: string
-          description: Optional trailer YouTube URL.
-          example: 'https://youtube.com/watch?v=trailer'
+          description: Optional trailer YouTube embed ID.
+          example: '1232133dew'
+        averageRating:
+          type: number
+          format: float
+          description: Optional average rating (0-10).
+          example: 8.7
     UpdateSeason:
       type: object
       description: Schema for updating an existing season. All fields are optional.
@@ -72,7 +77,7 @@ components:
         releaseDate:
           type: string
           description: Release date (ISO format, YYYY-MM-DD).
-          example: '2022-02-15'
+          example: '2022-02-15T00:00:00.000Z'
         noOfEpisodes:
           type: integer
           description: Number of episodes in the season.
@@ -92,10 +97,15 @@ components:
           description: Status of the season.
           enum: ['ended', 'upcoming', 'on-going']
           example: 'on-going'
-        trailerYoutubeUrl:
+        youtubeVideoId:
           type: string
-          description: Optional trailer YouTube URL.
-          example: 'https://youtube.com/watch?v=trailer'
+          description: Optional trailer YouTube embed ID.
+          example: '1232133dew'
+        averageRating:
+          type: number
+          format: float
+          description: Optional average rating (0-10).
+          example: 8.7
         tvShow:
           type: string
           description: MongoDB ObjectId string reference to the TV show.

--- a/src/common/validation-schema/tv-show/add-season.ts
+++ b/src/common/validation-schema/tv-show/add-season.ts
@@ -32,10 +32,13 @@ export const AddSeasonZodSchema = z.object({
     })
     .optional(),
 
-  releaseDate: z.string({
-    required_error: 'Release date is required',
-    message: 'Release date must be string',
-  }),
+  releaseDate: z
+    .string({
+      message: 'Release date must be  iso date string',
+    })
+    .datetime({ message: 'Release date must be in iso format' })
+    .transform((val) => new Date(val))
+    .optional(),
 
   noOfEpisodes: z.number({
     required_error: 'No of episodes is required',
@@ -62,10 +65,18 @@ export const AddSeasonZodSchema = z.object({
       message: `Status must be one of the following: ${SEASON_STATUS.join(', ')}`,
     }),
 
-  trailerYoutubeUrl: z
+  youtubeVideoId: z
     .string({
-      message: 'Trailer youtube url must be string',
+      message: 'Youtube id must be string',
     })
+    .optional(),
+
+  averageRating: z
+    .number({
+      message: 'Average rating must be a number',
+    })
+    .min(0, { message: 'Rating cannot be negative' })
+    .max(10, { message: 'Rating cannot be greater than 10' })
     .optional(),
 
   episodes: z.array(AddEpisodeZodSchema.omit({ season: true })).optional(),

--- a/src/models/tv-episode.ts
+++ b/src/models/tv-episode.ts
@@ -10,7 +10,7 @@ export interface IEpisode {
   title: string;
   description: string;
   episodeNumber: number;
-  releaseDate: string;
+  releaseDate?: Date;
   runTime?: number;
   stillUrl?: string;
   averageRating?: number;
@@ -37,8 +37,7 @@ const EpisodeSchema: Schema = new Schema(
       required: true,
     },
     releaseDate: {
-      type: String,
-      default: '',
+      type: Date,
     },
     runTime: {
       type: Number,

--- a/src/models/tv-season.ts
+++ b/src/models/tv-season.ts
@@ -10,12 +10,13 @@ export interface ISeason extends Document {
   tvShow: string;
   seasonNumber: number;
   description: string;
-  releaseDate: string;
+  releaseDate?: Date;
   noOfEpisodes: number;
   posterUrl: string;
   seasonRating?: number;
   status: string;
-  trailerYoutubeUrl: string;
+  youtubeVideoId?: string;
+  averageRating?: number;
 }
 
 // schema
@@ -39,8 +40,8 @@ const SeasonSchema: Schema = new Schema(
       default: '',
     },
     releaseDate: {
-      type: String,
-      required: true,
+      type: Date,
+      required: false,
     },
     noOfEpisodes: {
       type: Number,
@@ -59,10 +60,15 @@ const SeasonSchema: Schema = new Schema(
       required: true,
       enum: SEASON_STATUS,
     },
-    trailerYoutubeUrl: {
+    youtubeVideoId: {
       type: String,
       required: false,
-      default: '',
+    },
+    averageRating: {
+      type: Number,
+      required: false,
+      max: 10,
+      min: 0,
     },
   },
   { timestamps: true }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * TV seasons/episodes: Added averageRating and YouTube video ID; releaseDate now ISO 8601 date-time and optional; episodes include stillUrl and episode-level averageRating.
  * Movies: Added backdropUrl, isActive, status, tags, ageRating, youtubeVideoId; releaseDate converted to date type; runTime removed.
  * Games: Added developer, ageRating, youtubeVideoId; releaseDate converted to date type.
* **Documentation**
  * Updated API docs/examples and payloads to reflect new fields, ISO 8601 dates, and revised IDs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->