### PR TITLE
Rename runTime to avgRunTime and add new ID and rating fields to TV show model.

### DIFF
--- a/docs/atlas_index.md
+++ b/docs/atlas_index.md
@@ -117,7 +117,7 @@
       "releaseDate": {
         "type": "date"
       },
-      "runTime": {
+      "avgRunTime": {
         "type": "number"
       },
       "status": {

--- a/docs/phase1_models.md
+++ b/docs/phase1_models.md
@@ -21,18 +21,28 @@ The following is a description of the database models used in the application ph
 
 #### Table: TV Shows
 
-| Field Name    | Data Type     | Description                             |
-| ------------- | ------------- | --------------------------------------- |
-| title         | string        | TV show title                           |
-| description   | string        | TV show description                     |
-| averageRating | number        | TV show average rating                  |
-| genre         | array[string] | TV show genres (enum: `GENRE_MOVIE_TV`) |
-| releaseDate   | date          | TV show release date                    |
-| cast          | array[string] | TV show cast                            |
-| directors     | array[string] | TV show directors                       |
-| runTime       | number        | TV show run time                        |
-| languages     | array[string] | TV show languages                       |
-| posterUrl     | string        | TV show poster URL                      |
+| Field Name     | Data Type     | Description                             |
+| -------------- | ------------- | --------------------------------------- |
+| title          | string        | TV show title                           |
+| description    | string        | TV show description                     |
+| averageRating  | number        | TV show average rating                  |
+| genre          | array[string] | TV show genres (enum: `GENRE_MOVIE_TV`) |
+| releaseDate    | date          | TV show release date                    |
+| cast           | array[string] | TV show cast                            |
+| directors      | array[string] | TV show directors                       |
+| avgRunTime     | number        | TV show average run time                |
+| languages      | array[string] | TV show languages                       |
+| posterUrl      | string        | TV show poster URL                      |
+| backdropUrl    | string        | TV show backdrop URL                    |
+| isActive       | boolean       | TV show active status                   |
+| status         | string        | TV show status (enum: `MEDIA_STATUS`)   |
+| tags           | array[string] | TV show tags (enum: `TAGS`)             |
+| totalSeasons   | number        | TV show total seasons                   |
+| totalEpisodes  | number        | TV show total episodes                  |
+| ageRating      | number        | TV show age rating                      |
+| youtubeVideoId | string        | TV show trailer youtube embed ID        |
+| tmdbId         | string        | TV show tmdb id                         |
+| imdbId         | string        | TV show imdb id                         |
 
 ### TV Season Model
 

--- a/docs/rest_phase1.http
+++ b/docs/rest_phase1.http
@@ -1,5 +1,5 @@
 @baseUrl = http://localhost:3001
-@authToken = Bearer <token>
+@authToken = Bearer <TOKEN>
 ##-------------------------------------------- USER -------------------------------------------------------------
 ### add user
 POST {{baseUrl}}/api/user
@@ -282,7 +282,7 @@ GET {{baseUrl}}/api/tv-show?limit=2&start=0
 GET {{baseUrl}}/api/tv-show?limit=2&page=1&fullDetails=true
 
 ### get tv-show by id
-GET {{baseUrl}}/api/tv-show/68791c6b786a8844dec84b02
+GET {{baseUrl}}/api/tv-show/68e246153a5074bc7af65d3a
 
 ### get tv show by search title (pagination default limit = 20)
 GET {{baseUrl}}/api/tv-show/search?text=Fleabag
@@ -303,9 +303,9 @@ Content-Type: application/json
     "gte": "2016-01-13T00:00:00.000Z",
     "lte": "2017-01-13T00:00:00.000Z"
   },
-  "runTime":{
-    "gte": 200,
-    "lte": 300
+  "avgRunTime":{
+    "gte": 10,
+    "lte": 100
   },
   "totalEpisodes":{
     "gte": 5,
@@ -325,46 +325,56 @@ Authorization: {{authToken}}
 Content-Type: application/json
 
 {
-  "title": "Fleabag small bug",
+  "title": "Fleabag small bug 55",
   "description": "A dry-witted woman, known only as Fleabag, navigates life and love in London while trying to cope with tragedy.",
   "averageRating": 8.7,
   "genre": ["Comedy", "Action"],
   "releaseDate": "2016-01-13T00:00:00.000Z",
   "cast": ["Phoebe Waller-Bridge", "Sian Clifford", "Olivia Colman"],
   "directors": ["Harry Bradbeer"],
-  "runTime": 230,
+  "avgRunTime": 60,
   "languages": ["English"],
-  "posterUrl": "https://m.media-amazon.com/images/M/MV5BMjA4ODU3OTEzMl5BMl5BanBnXkFtZTgwMjc4NzA4OTE@._V1_QL75_UX380_CR0,0,380,562_.jpg",
-  "backdropUrl": "https://www.themoviedb.org/t/p/original/4FV98Rj42n22I5OQ6dM2p12lT1z.jpg",
+  "posterUrl": "https://image.tmdb.org/t/p/w600_and_h900_bestv2/yb4F1Oocq8GfQt6AgYEBokhG.jpg",
+  "backdropUrl": "https://image.tmdb.org/t/p/w600_and_h900_bestv2/yb4F1Oocq8GfiIuAgYEBokhG.jpg",
   "isActive": true,
   "status": "released",
-  "tags": ["Award-winning", "Character-driven", "Dialogue-heavy", "Satirical"],
-  "totalSeasons": 2,
-  "totalEpisodes": 12,
+  "tags": ["Award-winning"],
+  "totalSeasons": 1,
+  "totalEpisodes": 2,
   "ageRating": 16,
+  "tmdbId":"1236470",
+  "imdbId":"tt13443470",
+  "youtubeVideoId": "CrtcTnmuKhE",
   "seasons": [
     {
-      "seasonNumber": 1,
-      "title": "Season 1",
-      "description": "Fleabag navigates the minefield of her family and dating life while dealing with the recent death of her best friend.",
-      "releaseDate": "2016-07-21",
-      "noOfEpisodes": 6,
-      "posterUrl": "https://www.themoviedb.org/t/p/w220_and_h330_face/ohh0255e0x9a8y6eSyrDLi2hM96.jpg",
-      "seasonRating": 8.5,
+      "seasonNumber": 2,
+      "title": "Season 2",
+      "description": "The first season of The Startup.",
+      "releaseDate": "2023-09-10T00:00:00.000Z",
+      "noOfEpisodes": 2,
+      "posterUrl": "",
+      "seasonRating": 7.8,
       "status": "ended",
-      "trailerYoutubeUrl": "https://www.youtube.com/watch?v=I5Uv6cb9YRs",
+      "averageRating": 9,
+      "youtubeVideoId": "CrtcTnmuKhE",
       "episodes": [
         {
-          "title": "Episode 1",
-          "description": "Fleabag tries to navigate a tricky family lunch and a one-night stand.",
+          "title": "Launch Day",
+          "description": "The team scrambles to fix bugs before their big product launch.",
           "episodeNumber": 1,
-          "runTime": 27
+          "releaseDate": "2023-09-10T00:00:00.000Z",
+          "runTime": 30 ,
+          "stillUrl": "https://image.tmdb.org/t/p/w600_and_h900_bestv2/yb4F1Oocq8GfQt6iIuAgYEBokhG.jpg",
+          "averageRating": 9
         },
         {
-          "title": "Episode 2",
-          "description": "With the cafe struggling, Fleabag asks her sister for money, which results in a cringeworthy encounter with her brother-in-law.",
+          "title": "First Customer",
+          "description": "The startup gets its first customer, but things don't go as planned.",
           "episodeNumber": 2,
-          "runTime": 26
+          "releaseDate": "2023-09-10T00:00:00.000Z",
+          "runTime": 30 ,
+          "stillUrl": "https://image.tmdb.org/t/p/w600_and_h900_bestv2/yb4F1Oocq8GfQt6iIuAgYEBokhG.jpg",
+          "averageRating": 9
         }
       ]
     }
@@ -376,16 +386,17 @@ Content-Type: application/json
 POST {{baseUrl}}/api/tv-show/bulk
 
 ### update a tv show details (only meta data can be updated )
-PATCH {{baseUrl}}/api/tv-show/68791c6b786a8844dec84b02
+PATCH {{baseUrl}}/api/tv-show/68e246153a5074bc7af65d3a
 Authorization: {{authToken}}
 Content-Type: application/json
 
 {
-  "description": "A dry-witted woman, known only as Fleabag, navigates life and love in London while trying to cope with tragedy."
+  "description": "A dry-witted woman, known only as Fleabag, navigates life and love in London while trying to cope with tragedy.",
+  "avgRunTime": 40
 }
 
 ### delete a tv show (this will remove all the associated seasons and episodes)
-DELETE  {{baseUrl}}/api/tv-show/688658dbbe58cf4bf7ade6ce
+DELETE  {{baseUrl}}/api/tv-show/68e246153a5074bc7af65d3a
 Authorization: {{authToken}}
 
 ### bulk delete tv show

--- a/src/common/swagger/schema/tv-show.yml
+++ b/src/common/swagger/schema/tv-show.yml
@@ -11,7 +11,6 @@ components:
         - description
         - genre
         - releaseDate
-        - runTime
         - status
         - totalSeasons
         - totalEpisodes
@@ -29,6 +28,7 @@ components:
           description: The average rating of the TV show, on a scale of 0 to 10.
           format: float
           maximum: 10
+          minimum: 0
           example: 9.5
         genre:
           type: array
@@ -52,7 +52,7 @@ components:
           items:
             type: string
           example: ['Vince Gilligan']
-        runTime:
+        avgRunTime:
           type: integer
           description: Runtime of each episode, in minutes.
           example: 47
@@ -97,6 +97,18 @@ components:
           type: integer
           description: Suggested viewer age rating.
           example: 18
+        youtubeVideoId:
+          type: string
+          format: youtube video id
+          example: 'dQw4w9WgXcQ'
+        tmdbId:
+          type: string
+          format: tmdb id
+          example: '1399'
+        imdbId:
+          type: string
+          format: imdb id
+          example: 'tt0903747'
     TvShowResponseFull:
       allOf:
         - $ref: '#/components/schemas/TvShow'
@@ -126,47 +138,7 @@ components:
         application/json:
           schema:
             $ref: '#/components/schemas/TvShowResponseFull'
-          example:
-            title: 'Fleabag'
-            description: 'A dry-witted woman, known only as Fleabag, navigates life and love in London while trying to cope with tragedy.'
-            averageRating: 8.7
-            genre: ['Comedy', 'Drama']
-            releaseDate: '2016-07-21T00:00:00.000Z'
-            cast: ['Phoebe Waller-Bridge', 'Sian Clifford', 'Olivia Colman']
-            directors: ['Harry Bradbeer']
-            runTime: 27
-            languages: ['English']
-            posterUrl: 'https://m.media-amazon.com/images/M/MV5B...'
-            backdropUrl: 'https://www.themoviedb.org/t/p/original/...'
-            isActive: true
-            status: 'released'
-            tags:
-              - 'Award-winning'
-              - 'Character-driven'
-              - 'Dialogue-heavy'
-              - 'Satirical'
-            totalSeasons: 2
-            totalEpisodes: 12
-            ageRating: 16
-            seasons:
-              - seasonNumber: 1
-                title: 'Season 1'
-                description: 'Fleabag navigates...'
-                releaseDate: '2016-07-21T00:00:00.000Z'
-                noOfEpisodes: 6
-                posterUrl: 'https://www.themoviedb.org/t/p/w220_and_h330_face/ohh0255e0x9a8y6eSyrDLi2hM96.jpg'
-                seasonRating: 8.5
-                status: ended
-                trailerYoutubeUrl: 'https://www.youtube.com/watch?v=I5Uv6cb9YRs'
-                episodes:
-                  - title: 'Episode 1'
-                    description: 'Fleabag tries...'
-                    episodeNumber: 1
-                    runTime: 27
-                  - title: 'Episode 2'
-                    description: 'With the cafe struggling...'
-                    episodeNumber: 2
-                    runTime: 26
+  
     FilterTvShowBody:
       description: The request body for filtering TV Shows.
       required: true
@@ -216,9 +188,9 @@ components:
                     description: The maximum number of episodes.
                 example:
                   gte: 150
-              runTime:
+              avgRunTime:
                 type: object
-                description: Filter by a range for the episode run time in minutes.
+                description: Filter by a range for the average episode run time in minutes.
                 properties:
                   gte:
                     type: integer
@@ -314,52 +286,7 @@ components:
                 properties:
                   tvShow:
                     $ref: '#/components/schemas/TvShowResponseFull'
-          example:
-            success: true
-            message: 'Tv show created successfully'
-            data:
-              tvShow:
-                title: 'Fleabag'
-                description: 'A dry-witted woman, known only as Fleabag, navigates life and love in London while trying to cope with tragedy.'
-                averageRating: 8.7
-                genre: ['Comedy', 'Drama']
-                releaseDate: '2016-07-21'
-                cast: ['Phoebe Waller-Bridge', 'Sian Clifford', 'Olivia Colman']
-                directors: ['Harry Bradbeer']
-                runTime: 27
-                languages: ['English']
-                posterUrl: 'https://m.media-amazon.com/images/...jpg'
-                backdropUrl: 'https://www.themoviedb.org/t/p/original/...jpg'
-                isActive: true
-                status: 'released'
-                tags:
-                  - 'Award-winning'
-                  - 'Character-driven'
-                  - 'Dialogue-heavy'
-                  - 'Satirical'
-                totalSeasons: 2
-                totalEpisodes: 12
-                ageRating: 16
-                seasons:
-                  - seasonNumber: 1
-                    title: 'Season 1'
-                    description: 'Fleabag navigates the minefield of her family and dating life while dealing with the recent death of her best friend.'
-                    releaseDate: '2016-07-21'
-                    noOfEpisodes: 6
-                    posterUrl: 'https://www.themoviedb.org/t/...jpg'
-                    seasonRating: 8.5
-                    status: ended
-                    trailerYoutubeUrl: 'https://www.youtube.com/watch?v=I5Uv6cb9YRs'
-                    episodes:
-                      - title: 'Episode 1'
-                        description: 'Fleabag tries to navigate a tricky family lunch and a one-night stand.'
-                        episodeNumber: 1
-                        runTime: 27
-                      - title: 'Episode 2'
-                        description: 'With the cafe struggling, Fleabag asks her sister for money...'
-                        episodeNumber: 2
-                        runTime: 26
-
+          
     GetAllTvShowsSuccessResponse:
       description: Success response for getting all tv shows
       content:

--- a/src/common/swagger/schema/tv-show.yml
+++ b/src/common/swagger/schema/tv-show.yml
@@ -138,7 +138,7 @@ components:
         application/json:
           schema:
             $ref: '#/components/schemas/TvShowResponseFull'
-  
+
     FilterTvShowBody:
       description: The request body for filtering TV Shows.
       required: true
@@ -286,7 +286,7 @@ components:
                 properties:
                   tvShow:
                     $ref: '#/components/schemas/TvShowResponseFull'
-          
+
     GetAllTvShowsSuccessResponse:
       description: Success response for getting all tv shows
       content:

--- a/src/common/validation-schema/tv-show/add-tv-show.ts
+++ b/src/common/validation-schema/tv-show/add-tv-show.ts
@@ -154,9 +154,9 @@ export const AddTvShowZodSchema = z.object({
     })
     .optional(),
 
-  imdbRating: z
+  tmdbId: z
     .number({
-      message: 'Imdb rating must be number',
+      message: 'Tmdb id must be number',
     })
     .optional(),
 

--- a/src/common/validation-schema/tv-show/add-tv-show.ts
+++ b/src/common/validation-schema/tv-show/add-tv-show.ts
@@ -155,8 +155,8 @@ export const AddTvShowZodSchema = z.object({
     .optional(),
 
   tmdbId: z
-    .number({
-      message: 'Tmdb id must be number',
+    .string({
+      message: 'Tmdb id must be string',
     })
     .optional(),
 

--- a/src/common/validation-schema/tv-show/add-tv-show.ts
+++ b/src/common/validation-schema/tv-show/add-tv-show.ts
@@ -26,8 +26,10 @@ export const AddTvShowZodSchema = z.object({
     .number({
       message: 'Average rating must be number',
     })
+    .min(0, 'Average rating cannot be negative')
     .max(10, 'Average rating can be at most 10')
     .optional(),
+
   genre: z.array(
     z
       .string({
@@ -68,10 +70,11 @@ export const AddTvShowZodSchema = z.object({
     message: 'Directors must be an array of strings',
   }),
 
-  runTime: z.number({
-    required_error: 'Run time is required',
-    message: 'Run time must be number (in minutes)',
-  }),
+  avgRunTime: z
+    .number({
+      message: 'Run time must be number (in minutes)',
+    })
+    .optional(),
 
   languages: z
     .array(
@@ -136,6 +139,24 @@ export const AddTvShowZodSchema = z.object({
   ageRating: z
     .number({
       message: 'Age rating must be number',
+    })
+    .optional(),
+
+  youtubeVideoId: z
+    .string({
+      message: 'Youtube id must be string',
+    })
+    .optional(),
+
+  imdbId: z
+    .string({
+      message: 'Imdb id must be string',
+    })
+    .optional(),
+
+  imdbRating: z
+    .number({
+      message: 'Imdb rating must be number',
     })
     .optional(),
 

--- a/src/common/validation-schema/tv-show/tv-show-filter.ts
+++ b/src/common/validation-schema/tv-show/tv-show-filter.ts
@@ -73,7 +73,7 @@ export const FilterTvShowZodSchema = z.object({
     })
     .optional(),
 
-  runTime: z
+  avgRunTime: z
     .object({
       gte: z
         .number({

--- a/src/controllers/tv-show.controller.ts
+++ b/src/controllers/tv-show.controller.ts
@@ -372,7 +372,7 @@ export const filterTvShow = async (
       status,
       averageRating,
       releaseDate,
-      runTime,
+      avgRunTime,
       tags,
       totalEpisodes,
       totalSeasons,
@@ -448,11 +448,11 @@ export const filterTvShow = async (
     }
 
     //check if runTime is defined
-    if (runTime) {
+    if (avgRunTime) {
       searchClauses.filter.push({
         range: {
-          path: 'runTime',
-          ...runTime,
+          path: 'avgRunTime',
+          ...avgRunTime,
         },
       });
     }

--- a/src/models/tv-show.mode.ts
+++ b/src/models/tv-show.mode.ts
@@ -13,12 +13,12 @@ import {
 export interface ITVShow extends Document {
   title: string;
   description: string;
-  averageRating: number;
+  averageRating?: number;
   genre: string[];
   releaseDate: Date;
   cast: string[];
   directors: string[];
-  runTime: number;
+  avgRunTime?: number;
   languages: string[];
   posterUrl: string;
   backdropUrl: string;
@@ -27,7 +27,10 @@ export interface ITVShow extends Document {
   tags: string[];
   totalSeasons: number;
   totalEpisodes: number;
-  ageRating: number;
+  ageRating?: number;
+  youtubeVideoId?: string;
+  tmdbId?: string;
+  imdbId?: string;
 }
 
 //schema
@@ -45,6 +48,7 @@ const TVShowSchema: Schema = new Schema(
     averageRating: {
       type: Number,
       required: false,
+      min: 0,
       max: 10,
     },
     genre: {
@@ -66,9 +70,9 @@ const TVShowSchema: Schema = new Schema(
       required: false,
       default: [],
     },
-    runTime: {
+    avgRunTime: {
       type: Number,
-      required: true,
+      required: false,
     },
     languages: {
       type: [String],
@@ -110,6 +114,19 @@ const TVShowSchema: Schema = new Schema(
     },
     ageRating: {
       type: Number,
+      required: false,
+    },
+    youtubeVideoId: {
+      type: String,
+      required: false,
+      default: '',
+    },
+    tmdbId: {
+      type: String,
+      required: false,
+    },
+    imdbId: {
+      type: String,
       required: false,
     },
   },


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Replaced runTime with avgRunTime across APIs, filters, and payloads.
  * Added TV show fields: youtubeVideoId, tmdbId, imdbId, backdropUrl, isActive, status, tags, totalSeasons, totalEpisodes, ageRating.
  * Get-all TV shows now returns a tvShows array.

* **Bug Fixes**
  * averageRating now enforces a non-negative minimum.

* **Documentation**
  * Updated models, examples, schemas, and request/response descriptions to reflect renames and new fields.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->