### PR TITLE
Dev - fixes to tv season model

### DIFF
--- a/src/common/swagger/schema/tv-season.yml
+++ b/src/common/swagger/schema/tv-season.yml
@@ -37,12 +37,6 @@ components:
           type: string
           description: Optional poster image URL.
           example: 'http://example.com/season1-poster.jpg'
-        seasonRating:
-          type: number
-          format: float
-          description: Optional average rating (0-10).
-          example: 8.7
-          maximum: 10
         status:
           type: string
           description: Status of the season.
@@ -86,12 +80,6 @@ components:
           type: string
           description: Optional poster image URL.
           example: 'http://example.com/season1-poster.jpg'
-        seasonRating:
-          type: number
-          format: float
-          description: Optional average rating (0-10).
-          example: 8.7
-          maximum: 10
         status:
           type: string
           description: Status of the season.

--- a/src/common/validation-schema/tv-show/add-season.ts
+++ b/src/common/validation-schema/tv-show/add-season.ts
@@ -51,12 +51,6 @@ export const AddSeasonZodSchema = z.object({
     })
     .optional(),
 
-  seasonRating: z
-    .number({
-      message: 'Season rating must be number',
-    })
-    .optional(),
-
   status: z
     .string({
       required_error: 'Status is required',

--- a/src/models/tv-season.ts
+++ b/src/models/tv-season.ts
@@ -12,8 +12,6 @@ export interface ISeason extends Document {
   description: string;
   releaseDate?: Date;
   noOfEpisodes: number;
-  posterUrl: string;
-  seasonRating?: number;
   status: string;
   youtubeVideoId?: string;
   averageRating?: number;
@@ -50,10 +48,6 @@ const SeasonSchema: Schema = new Schema(
     posterUrl: {
       type: String,
       default: '',
-    },
-    seasonRating: {
-      type: Number,
-      required: false,
     },
     status: {
       type: String,


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Refactor
  - Removed season rating from TV season data. This field is no longer accepted on season creation/update and will not appear in responses.
  - Removed poster image URL from TV season data. This field will no longer appear in responses.
  - UI and integrations that previously displayed or relied on these fields should be updated to avoid showing empty data or sending unused fields.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->