### PR TITLE
added pack poster Url as it is still required

### DIFF
--- a/src/models/tv-season.ts
+++ b/src/models/tv-season.ts
@@ -12,6 +12,7 @@ export interface ISeason extends Document {
   description: string;
   releaseDate?: Date;
   noOfEpisodes: number;
+  posterUrl: string;
   status: string;
   youtubeVideoId?: string;
   averageRating?: number;


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * TV seasons now support poster images. When available, posters are displayed in season lists and detail views for improved visual context.
  * If no poster is provided, a default placeholder is used to maintain a consistent layout.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->