### PR TITLE
Add endpoints to fetch games and movies with user entry contex

### DIFF
--- a/docs/phase6_planning.md
+++ b/docs/phase6_planning.md
@@ -1,0 +1,75 @@
+# Phase 6 API Planning: User-Media Integration & Unified Detail Routes
+
+## Overview
+
+Phase 6 focuses on providing integrated endpoints that bridge public media data (Movies, TV Shows, Games) with private user collection data (`MediaEntry`). The primary goal is to allow the frontend to fetch a single object that contains both the media's static information and the current user's personal status/rating for that media, if it exists.
+
+To clearly communicate that these endpoints merge user context, they will follow the `/:id/with-entry` naming convention.
+
+## Objectives
+
+- Implement "Unified Detail" routes for Movies, TV Shows, and Games using the `/:id/with-entry` path.
+- Ensure these routes handle both authenticated and unauthenticated requests gracefully (returning `userEntry: null` for guests or if no entry exists).
+
+---
+
+## Proposed Route Changes
+
+### 1. Movie Routes (`/api/movie`)
+
+- **GET /api/movie/:id/with-entry**: Returns full movie details merged with the authenticated user's `MediaEntry`.
+
+### 2. TV Show Routes (`/api/tv-show`)
+
+- **GET /api/tv-show/:id/with-entry**: Returns full TV show details merged with the user's `MediaEntry`.
+
+### 3. Game Routes (`/api/game`)
+
+- **GET /api/game/:id/with-entry**: Returns game details merged with the user's `MediaEntry`.
+
+---
+
+## Technical Details
+
+### Middleware: `optionalAuth`
+
+To support these unified routes, we need a middleware that extracts user information if a token is present but doesn't block the request if it isn't.
+
+- If `req.user` is present, the controller will query `MediaEntry` for `user_id` + `media_id`.
+- If `req.user` is absent, `userEntry` will be `null`.
+
+### Response Structure
+
+```json
+{
+  "success": true,
+  "data": {
+    "media": { ...mediaDetails... },
+    "userEntry": { ...mediaEntryDetails... } // or null if unauthenticated / no entry
+  }
+}
+```
+
+---
+
+## Tasks Breakdown
+
+### Development Tasks
+
+- [ ] Implement `optionalAuth` middleware.
+- [ ] Update `MovieController`:
+  - [ ] Create `getMovieDetailWithUserContext` controller.
+- [ ] Update `TvShowController`:
+  - [ ] Create `getTvShowDetailWithUserContext` controller.
+- [ ] Update `GameController`:
+  - [ ] Create `getGameDetailWithUserContext` controller.
+- [ ] Register new `/:id/with-entry` routes in respective route files.
+
+### Testing Tasks
+
+- [ ] Add unit tests for the new "Detail with User Context" controllers.
+- [ ] Add integration tests for guest vs. authenticated user responses.
+
+### Documentation Tasks
+
+- [ ] Update Swagger documentation for all new `/:id/with-entry` endpoints.

--- a/docs/phase6_planning.md
+++ b/docs/phase6_planning.md
@@ -9,7 +9,7 @@ To clearly communicate that these endpoints merge user context, they will follow
 ## Objectives
 
 - Implement "Unified Detail" routes for Movies, TV Shows, and Games using the `/:id/with-entry` path.
-- Ensure these routes handle both authenticated and unauthenticated requests gracefully (returning `userEntry: null` for guests or if no entry exists).
+- Ensure these routes handle both authenticated and unauthenticated requests gracefully (returning `mediaEntry: null` for guests or if no entry exists).
 
 ---
 
@@ -36,7 +36,7 @@ To clearly communicate that these endpoints merge user context, they will follow
 To support these unified routes, we need a middleware that extracts user information if a token is present but doesn't block the request if it isn't.
 
 - If `req.user` is present, the controller will query `MediaEntry` for `user_id` + `media_id`.
-- If `req.user` is absent, `userEntry` will be `null`.
+- If `req.user` is absent, `mediaEntry` will be `null`.
 
 ### Response Structure
 
@@ -45,7 +45,7 @@ To support these unified routes, we need a middleware that extracts user informa
   "success": true,
   "data": {
     "media": { ...mediaDetails... },
-    "userEntry": { ...mediaEntryDetails... } // or null if unauthenticated / no entry
+    "mediaEntry": { ...mediaEntryDetails... } // or null if unauthenticated / no entry
   }
 }
 ```

--- a/docs/rest_phase6.http
+++ b/docs/rest_phase6.http
@@ -5,3 +5,10 @@
 ### get game by id with user context
 GET {{baseUrl}}/api/game/696da5c214ab5aefab34a9e1/with-entry
 Authorization: {{authToken}}
+
+
+
+#---------------------------------Movie--------------------------------------------------------------------------------------
+### get movie by id with user context
+GET {{baseUrl}}/api/movie/69dbc20c4f143d20e0fe2b23/with-entry
+Authorization: {{authToken}}

--- a/docs/rest_phase6.http
+++ b/docs/rest_phase6.http
@@ -1,0 +1,7 @@
+@baseUrl = http://localhost:3001
+@authToken = Bearer <token>
+
+#---------------------------------Games--------------------------------------------------------------------------------------
+### get game by id with user context
+GET {{baseUrl}}/api/game/696da5c214ab5aefab34a9e1/with-entry
+Authorization: {{authToken}}

--- a/src/common/swagger/schema/game.yml
+++ b/src/common/swagger/schema/game.yml
@@ -531,5 +531,5 @@ components:
                 properties:
                   game:
                     $ref: '#/components/schemas/Game'
-                  userEntry:
+                  mediaEntry:
                     $ref: '#/components/schemas/MediaEntries'

--- a/src/common/swagger/schema/game.yml
+++ b/src/common/swagger/schema/game.yml
@@ -509,3 +509,27 @@ components:
                     type: array
                     items:
                       $ref: '#/components/schemas/Game'
+    GetGameWithUserEntrySuccessResponse:
+      description: success response of getting a game with user entry data
+      content:
+        application/json:
+          schema:
+            type: object
+            required:
+              - success
+              - requestId
+              - data
+            properties:
+              success:
+                type: boolean
+                example: true
+              requestId:
+                type: string
+                example: 'aa636e0e-13e8-472c-874c-3aac8ae00000'
+              data:
+                type: object
+                properties:
+                  game:
+                    $ref: '#/components/schemas/Game'
+                  userEntry:
+                    $ref: '#/components/schemas/MediaEntries'

--- a/src/common/swagger/schema/movie.yml
+++ b/src/common/swagger/schema/movie.yml
@@ -516,5 +516,5 @@ components:
                 properties:
                   movie:
                     $ref: '#/components/schemas/Movie'
-                  userEntry:
+                  mediaEntry:
                     $ref: '#/components/schemas/MediaEntries'

--- a/src/common/swagger/schema/movie.yml
+++ b/src/common/swagger/schema/movie.yml
@@ -493,3 +493,28 @@ components:
               message:
                 type: string
                 example: 'Movie updated successfully'
+
+    GetMovieWithUserEntrySuccessResponse:
+      description: Success response of getting a movie with user entry data
+      content:
+        application/json:
+          schema:
+            type: object
+            required:
+              - success
+              - requestId
+              - data
+            properties:
+              success:
+                type: boolean
+                example: true
+              requestId:
+                type: string
+                example: 'aa636e0e-13e8-472c-874c-3aac8ae00000'
+              data:
+                type: object
+                properties:
+                  movie:
+                    $ref: '#/components/schemas/Movie'
+                  userEntry:
+                    $ref: '#/components/schemas/MediaEntries'

--- a/src/controllers/game.controller.ts
+++ b/src/controllers/game.controller.ts
@@ -6,6 +6,7 @@ import { handleError } from '../common/utils/handle-error';
 import { NextFunction, Response } from 'express';
 import { ValidatedRequest } from '../types/custom-types';
 import Game from '../models/game.model';
+import MediaEntry from '../models/media-entry';
 import {
   isDuplicateKeyError,
   isMongoIdValid,
@@ -559,5 +560,55 @@ export const filterGames = async (
     handleError(res, {
       error: err,
     });
+  }
+};
+
+//get game details with user context (media entry)
+export const getGameDetailWithUserContext = async (
+  req: ValidatedRequest<{}>,
+  res: Response
+) => {
+  try {
+    const { id } = req.params;
+    // @ts-ignore
+    const user = req.userData;
+
+    // validate id
+    if (!isMongoIdValid(id)) {
+      handleError(res, { message: 'Invalid game id', statusCode: 400 });
+      return;
+    }
+
+    // fetch game and media entry in parallel
+    const [game, mediaEntry] = await Promise.all([
+      Game.findById(id).lean().exec(),
+      user
+        ? MediaEntry.findOne({
+            user: user._id,
+            mediaItem: id,
+            onModel: 'Game',
+          })
+            .lean()
+            .exec()
+        : Promise.resolve(null),
+    ]);
+
+    // if game is not found
+    if (!game) {
+      handleError(res, { message: 'Game not found', statusCode: 404 });
+      return;
+    }
+
+    //send response
+    res.status(200).json({
+      success: true,
+      data: {
+        game,
+        mediaEntry,
+      },
+    });
+  } catch (err) {
+    // handle unexpected error
+    handleError(res, { error: err });
   }
 };

--- a/src/controllers/movie.controller.ts
+++ b/src/controllers/movie.controller.ts
@@ -26,6 +26,7 @@ import {
   appendOldAndNewDoc,
   appendOldDoc,
 } from '../common/utils/history-utils';
+import MediaEntry from '../models/media-entry';
 
 // controller to add a new movie
 export const addMovie = async (
@@ -590,5 +591,50 @@ export const getMoviesWithFilters = async (
     handleError(res, {
       error: err,
     });
+  }
+};
+
+/**
+ * get a movie by id with populated user entry
+ */
+export const getMovieDetailWithUserContext = async (
+  req: ValidatedRequest<{}>,
+  res: Response
+) => {
+  try {
+    // get media id
+    const { id } = req.params;
+    const user = req?.userData;
+
+    // validate id
+    if (!isMongoIdValid(id)) {
+      handleError(res, { message: 'Invalid movie id', statusCode: 400 });
+      return;
+    }
+
+    // fetch the movie and user entry in parallel
+    const [movie, mediaEntry] = await Promise.all([
+      Movie.findById(id).lean().exec(),
+      user
+        ? MediaEntry.findOne({ user: user.id, mediaItem: id, onModel: 'Movie' })
+            .lean()
+            .exec()
+        : null,
+    ]);
+
+    // handle if movie not found
+    if (!movie) {
+      handleError(res, { message: 'Movie not found', statusCode: 404 });
+      return;
+    }
+
+    // return the movie
+    res.status(200).json({
+      success: true,
+      data: { movie, mediaEntry },
+    });
+  } catch (err) {
+    // handle unexpected error
+    handleError(res, { error: err });
   }
 };

--- a/src/routes/game.route.ts
+++ b/src/routes/game.route.ts
@@ -13,7 +13,9 @@ import {
   bulkAddGames,
   filterGames,
   searchGame,
+  getGameDetailWithUserContext,
 } from '../controllers/game.controller';
+import { optionalAuth } from '../common/middleware/require-auth';
 import { validateReq } from '../common/middleware/handle-validation';
 import { AddGameZodSchema } from '../common/validation-schema/game/add-game';
 import { requireAuth } from '../common/middleware/require-auth';
@@ -115,6 +117,31 @@ route.get('/search', searchGame);
  *         $ref: '#/components/responses/BadRequest'
  *  */
 route.get('/:id', getGameById);
+
+/**
+ * @swagger
+ * /api/game/{id}/with-entry:
+ *   get:
+ *     summary: Get game details with user context (media entry)
+ *     tags: [Games]
+ *     parameters:
+ *       - name: id
+ *         in: path
+ *         required: true
+ *         schema:
+ *           type: string
+ *         description: valid mongo id
+ *     responses:
+ *       '200':
+ *         $ref: '#/components/responses/GetGameWithUserEntrySuccessResponse'
+ *       '500':
+ *         $ref: '#/components/responses/InternalServerError'
+ *       '404':
+ *         $ref: '#/components/responses/NotFound'
+ *       '400':
+ *         $ref: '#/components/responses/BadRequest'
+ */
+route.get('/:id/with-entry', optionalAuth(), getGameDetailWithUserContext);
 
 /**
  * @swagger

--- a/src/routes/movie.route.ts
+++ b/src/routes/movie.route.ts
@@ -13,8 +13,9 @@ import {
   addBulkMovies,
   searchMovies,
   getMoviesWithFilters,
+  getMovieDetailWithUserContext,
 } from '../controllers/movie.controller';
-import { requireAuth } from '../common/middleware/require-auth';
+import { optionalAuth, requireAuth } from '../common/middleware/require-auth';
 import { validateReq } from '../common/middleware/handle-validation';
 import { AddMovieZodSchema } from '../common/validation-schema/movie/add-movie';
 import { updateMoveZodSchema } from '../common/validation-schema/movie/update-movie';
@@ -137,6 +138,11 @@ route.post('/filter', validateReq(MovieFiltersZodSchema), getMoviesWithFilters);
  *         $ref: '#/components/responses/BadRequest'
  */
 route.get('/:id', getMovieById);
+
+/**
+ * route to get the movie with populated media entry if user is logged in
+ */
+route.get('/:id/with-entry', optionalAuth(), getMovieDetailWithUserContext);
 
 /**
  * @swagger

--- a/src/routes/movie.route.ts
+++ b/src/routes/movie.route.ts
@@ -123,7 +123,7 @@ route.post('/filter', validateReq(MovieFiltersZodSchema), getMoviesWithFilters);
  *     parameters:
  *       - name: id
  *         in: path
- *         required:
+ *         required: true
  *         schema:
  *           type: string
  *         description: valid mongo id
@@ -148,7 +148,7 @@ route.get('/:id', getMovieById);
  *     parameters:
  *       - name: id
  *         in: path
- *         required:
+ *         required: true
  *         schema:
  *           type: string
  *         description: valid mongo id

--- a/src/routes/movie.route.ts
+++ b/src/routes/movie.route.ts
@@ -140,7 +140,27 @@ route.post('/filter', validateReq(MovieFiltersZodSchema), getMoviesWithFilters);
 route.get('/:id', getMovieById);
 
 /**
- * route to get the movie with populated media entry if user is logged in
+ * @swagger
+ * /api/movie/{id}/with-entry:
+ *   get:
+ *     summary: Get movie by id with user entry context
+ *     tags: [Movies]
+ *     parameters:
+ *       - name: id
+ *         in: path
+ *         required:
+ *         schema:
+ *           type: string
+ *         description: valid mongo id
+ *     responses:
+ *       '200':
+ *         $ref: '#/components/responses/GetMovieWithUserEntrySuccessResponse'
+ *       '500':
+ *         $ref: '#/components/responses/InternalServerError'
+ *       '404':
+ *         $ref: '#/components/responses/NotFound'
+ *       '400':
+ *         $ref: '#/components/responses/BadRequest'
  */
 route.get('/:id/with-entry', optionalAuth(), getMovieDetailWithUserContext);
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added unified detail endpoints for movies and games that return media details alongside user-specific entry data (or `null` for unauthenticated users).

* **Documentation**
  * Added API planning documentation and Swagger/OpenAPI specifications for the new endpoints.
  * Included REST client examples for testing the new endpoints.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->